### PR TITLE
Added support for Google Drive id format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 Fetch information about any public Google document.\
 It's working on :
+- Google Drive
 - Google Docs
 - Google Spreadsheets
 - Google Slides

--- a/xeuledoc/core.py
+++ b/xeuledoc/core.py
@@ -24,7 +24,7 @@ class TMPrinter():
 
 def doc_hunt(doc_link, tmprinter):
 
-    doc_id = ''.join([x for x in doc_link.split("?")[0].split("/") if len(x) == 44])
+    doc_id = ''.join([x for x in doc_link.split("?")[0].split("/") if len(x) in (33, 44)])
     if doc_id:
         print(f"\nDocument ID : {doc_id}\n")
     else:


### PR DESCRIPTION
I've found that xeuledoc's method also works for 33-letter Google Drive IDs. So, it will work for any shared GDrive file. 

Example: https://drive.google.com/file/d/12DzAQMgTcgeG-zJrfDxpUbFjlXcBq5ih/view